### PR TITLE
Defining mongodb module as a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   "dependencies": {
     "mongoose": "3.6.11",
     "request": "2.25.0",
-    "async": "0.2.9"
+    "async": "0.2.9",
+    "mongodb": "1.3.15"
   },
   "devDependencies": {
-    "mocha": "1.8.1",
-    "mongodb": "1.3.15"
+    "mocha": "1.8.1"
   },
   "engines": {
     "node": ">=0.6.0"


### PR DESCRIPTION
Currently the `mongodb` module is not a production dependency, so it fails to install from NPM. Throwing this error:

```
module.js:338
    throw err;
    ^
Error: Cannot find module 'mongodb'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/markotom/Codes/verbaceleberrima/node_modules/elmongo/lib/mapping.js:4:13)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/markotom/Codes/verbaceleberrima/node_modules/elmongo/lib/sync.js:10:15)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/markotom/Codes/verbaceleberrima/node_modules/elmongo/lib/elmongo.js:6:12)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
```
